### PR TITLE
fix bug where 0.1 was parsed wrong

### DIFF
--- a/src/number_parsing.zig
+++ b/src/number_parsing.zig
@@ -905,8 +905,8 @@ inline fn compute_float_64(power: i64, _i: u64, negative: bool, d: *f64) bool {
     const exponent: i64 = (((152170 + 65536) * power) >> 16) + 1024 + 63;
 
     // We want the most significant bit of i to be 1. Shift if needed.
-    var lz = @intCast(u6, @clz(u64, i));
-    i <<= lz;
+    var lz = @intCast(u7, @clz(u64, i));
+    i <<= @intCast(u6, lz);
 
     // We are going to need to do some 64-bit arithmetic to get a precise product.
     // We use a table lookup approach.
@@ -979,7 +979,7 @@ inline fn compute_float_64(power: i64, _i: u64, negative: bool, d: *f64) bool {
     ///////
     const upperbit = @intCast(u6, upper >> 63);
     var mantissa: u64 = upper >> (upperbit + 9);
-    lz +%= @intCast(u6, 1 ^ upperbit);
+    lz +%= 1 ^ upperbit;
 
     // Here we have mantissa < (1<<54).
     var real_exponent: i64 = exponent - lz;

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -112,7 +112,7 @@ test "float" {
         try testing.expectApproxEqAbs(@as(f64, 123.456), d, 0.000000001);
     }
     {
-        var parser = try dom.Parser.initFixedBuffer(allr, "[-0.000000000000000000000000000000000000000000000000000000000000000000000000000001]", .{});
+        var parser = try dom.Parser.initFixedBuffer(allr, "[-0.000000000000000000000000000000000000000000000000000000000000000000000000000001,0.1,0.01]", .{});
         defer parser.deinit();
         try parser.parse();
         // for (parser.doc.tape.items) |tape_item, i|
@@ -124,6 +124,24 @@ test "float" {
         try testing.expectApproxEqAbs(
             @as(f64, 0.000000000000000000000000000000000000000000000000000000000000000000000000000001),
             @bitCast(f64, parser.doc.tape.items[3]),
+            std.math.f64_epsilon,
+        );
+        try testing.expectEqual(
+            TapeType.DOUBLE.encode_value(0),
+            parser.doc.tape.items[4],
+        );
+        try testing.expectApproxEqAbs(
+            @as(f64, 0.1),
+            @bitCast(f64, parser.doc.tape.items[5]),
+            std.math.f64_epsilon,
+        );
+        try testing.expectEqual(
+            TapeType.DOUBLE.encode_value(0),
+            parser.doc.tape.items[6],
+        );
+        try testing.expectApproxEqAbs(
+            @as(f64, 0.01),
+            @bitCast(f64, parser.doc.tape.items[7]),
             std.math.f64_epsilon,
         );
     }


### PR DESCRIPTION
For numbers with lz = 63 before the multiply and multiply results with a leading zero, lz would overflow and become 0, so the parsed result would be too big by a factor of 2^64. Some numbers like this are 0.1 and 0.01. Added these to the test.